### PR TITLE
Change pyCrypto for pyCryptodome; Fix RSA output

### DIFF
--- a/pkiutils/__init__.py
+++ b/pkiutils/__init__.py
@@ -54,8 +54,9 @@ def create_rsa_key(bits=2048,
         passphrase = passphrase()
     output = rsakey.exportKey(format=format, passphrase=passphrase)
     if keyfile:
-        with open(keyfile, 'w') as outputfile:
+        with open(keyfile, 'wb') as outputfile:
             outputfile.write(output)
+
     log.info("generated private key:\n\n%s", output)
     return rsakey
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     name='pkiutils',
     description='a set of public key infrastructure utilities',
     long_description=DESCRIPTION,
-    install_requires=['pycrypto', 'pyasn1', 'pyasn1_modules', 'netaddr'],
+    install_requires=["pycryptodome", 'pyasn1', 'pyasn1_modules', 'netaddr'],
     version=0.1,
     author=__author__,
     author_email='jan@dittberner.info',


### PR DESCRIPTION
pyCrypto does not work with Python > 3.3. Use pyCryptodome instead.
